### PR TITLE
Bugfixes for func flow id origin & function dedup

### DIFF
--- a/compiler/code-object.lisp
+++ b/compiler/code-object.lisp
@@ -1,7 +1,7 @@
 (in-package :varjo)
 
 (defun code! (&key (type nil set-type) (current-line "") signatures to-block
-		to-top out-vars used-types returns multi-vals stemcells
+		out-vars used-types returns multi-vals stemcells
 		out-of-scope-args injected-uniforms flow-ids mutations place-tree
 		node-tree)
   (assert-flow-id-singularity flow-ids)
@@ -24,7 +24,6 @@
 		   :current-line current-line
 		   :signatures signatures
 		   :to-block to-block
-		   :to-top to-top
 		   :out-vars out-vars
 		   :returns returns
 		   :used-types used-types
@@ -69,7 +68,6 @@
                         (current-line nil set-current-line)
                         (signatures nil set-sigs)
                         (to-block nil set-block)
-                        (to-top nil set-top)
                         (out-vars nil set-out-vars)
                         (returns nil set-returns)
                         (multi-vals nil set-multi-vals)
@@ -89,7 +87,6 @@
 			     (current-line code-obj))
 	   :signatures (if set-sigs signatures (signatures code-obj))
 	   :to-block (if set-block to-block (remove nil (to-block code-obj)))
-	   :to-top (if set-top to-top (remove nil (to-top code-obj)))
 	   :out-vars (if set-out-vars out-vars (out-vars code-obj))
 	   :returns (listify (if set-returns returns (returns code-obj)))
 	   :used-types (used-types code-obj)
@@ -111,7 +108,6 @@
                         current-line
                         (signatures nil set-sigs)
                         (to-block nil set-block)
-                        (to-top nil set-top)
                         (out-vars nil set-out-vars)
                         (returns nil set-returns)
                         multi-vals
@@ -130,7 +126,6 @@
 			 (mapcat #'signatures objs))
 	 :to-block (if set-block to-block
 		       (mapcat #'to-block objs))
-	 :to-top (if set-top to-top (mapcat #'to-top objs))
 	 :out-vars (if set-out-vars out-vars (mapcat #'out-vars objs))
 	 :returns (listify (if set-returns returns (merge-returns objs)))
 	 :used-types (mapcar #'used-types objs)

--- a/compiler/compile-funcall.lisp
+++ b/compiler/compile-funcall.lisp
@@ -63,7 +63,6 @@
     (values (merge-obs args
 		       :type type
 		       :current-line c-line
-		       :to-top (mapcat #'to-top args)
 		       :signatures (mapcat #'signatures args)
 		       :stemcells (mapcat #'stemcells args)
 		       :flow-ids flow-ids
@@ -144,7 +143,6 @@
              (o (merge-obs
                  args :type type
                  :current-line (gen-function-string func args m-r-names)
-                 :to-top (mapcat #'to-top args)
                  :signatures (mapcat #'signatures args)
                  :stemcells (mapcat #'stemcells args)
                  :multi-vals (mapcar (lambda (_ _1 fid)

--- a/compiler/compile-special.lisp
+++ b/compiler/compile-special.lisp
@@ -102,7 +102,6 @@
 	     :to-block (append (mapcat #'to-block code-objs)
 			       (mapcar (lambda (_) (current-line (end-line _)))
 				       code-objs))
-	     :to-top (mapcat #'to-top code-objs)
 	     :flow-ids nil
 	     :node-tree :ignored))
 
@@ -131,15 +130,12 @@
 	      (flow-ids new-value)
 	      (flow-ids code-obj)))
 	 (to-block (when new-value
-		     (to-block new-value)))
-	 (to-top (when new-value
-		   (to-top new-value))))
+		     (to-block new-value))))
     (copy-code code-obj
 	       :type (code-type code-obj)
 	       :current-line current-line
 	       :flow-ids flow-ids
 	       :to-block to-block
-	       :to-top to-top
 	       :node-tree :ignored
 	       :multi-vals nil
 	       :place-tree nil)))

--- a/compiler/environment.lisp
+++ b/compiler/environment.lisp
@@ -55,9 +55,6 @@
 (defmethod v-iuniforms ((e environment))
   (v-iuniforms (get-base-env e)))
 
-(defmethod v-code-cache ((env environment))
-  (v-code-cache (get-base-env env)))
-
 (defmethod v-raw-in-args ((env environment))
   (v-raw-in-args (get-base-env env)))
 

--- a/compiler/environment.lisp
+++ b/compiler/environment.lisp
@@ -10,12 +10,15 @@
 	  (push (cons stem-cell-symbol flow-id) stemcell->flow-id)
 	  flow-id))))
 
-(defmethod push-non-implicit-function-for-dedup (code func (e environment))
-  (push (cons code func) (slot-value (get-base-env e) 'function-dedup)))
+(defmethod push-non-implicit-function-for-dedup (code func string (e environment))
+  (push (list code func string) (slot-value (get-base-env e) 'function-dedup)))
 
 (defmethod dedup-function (code (e environment))
-  (cdr (find code (slot-value (get-base-env e) 'function-dedup)
-	     :key #'car :test #'equal)))
+  (second (find code (slot-value (get-base-env e) 'function-dedup)
+                :key #'car :test #'equal)))
+
+(defmethod func-defs-glsl ((e environment))
+  (reverse (mapcar #'third (slot-value (get-base-env e) 'function-dedup))))
 
 (defmethod used-external-functions ((e environment))
   (slot-value (get-base-env e) 'used-external-functions))

--- a/compiler/generics.lisp
+++ b/compiler/generics.lisp
@@ -51,16 +51,16 @@
 (defgeneric v-special-functionp (func))
 (defgeneric v-element-type (object))
 (defgeneric merge-obs (objs &key type current-line to-block
-                              to-top out-vars returns multi-vals
+                              out-vars returns multi-vals
                               stemcells out-of-scope-args flow-ids
 			      place-tree mutations node-tree))
-(defgeneric copy-code (code-obj &key type current-line to-block to-top
+(defgeneric copy-code (code-obj &key type current-line to-block
                                   out-vars returns multi-vals
                                   stemcells out-of-scope-args flow-ids
 				  place-tree mutations node-tree))
 (defgeneric flow-id-origins (node &optional error-on-missingp context))
 
-(defgeneric push-non-implicit-function-for-dedup (code func e))
+(defgeneric push-non-implicit-function-for-dedup (code func glsl e))
 (defgeneric func-need-arguments-compiledp (func))
 (defgeneric get-macro (macro-name env))
 (defgeneric get-symbol-macro (macro-name env))

--- a/compiler/internal-types.lisp
+++ b/compiler/internal-types.lisp
@@ -106,7 +106,6 @@
    (in-args :initform nil :initarg :in-args :accessor v-in-args)
    (uniforms :initform nil :initarg :uniforms :accessor v-uniforms)
    (context :initform nil :initarg :context :accessor v-context)
-   (function-code-cache :initform (make-hash-table) :reader v-code-cache)
    (used-external-functions :initform nil :initarg :used-external-functions)
    (used-symbol-macros :initform nil :initarg :used-symbol-macros)
    (used-macros :initform nil :initarg :used-macros)

--- a/compiler/internal-types.lisp
+++ b/compiler/internal-types.lisp
@@ -22,7 +22,6 @@
    (current-line :initarg :current-line :initform "" :reader current-line)
    (signatures :initarg :signatures :initform nil :reader signatures)
    (to-block :initarg :to-block :initform nil :reader to-block)
-   (to-top :initarg :to-top :initform nil :reader to-top)
    (out-vars :initarg :out-vars :initform nil :reader out-vars)
    (used-types :initarg :used-types :initform nil :reader used-types)
    (returns :initarg :returns :initform nil :reader returns)
@@ -52,6 +51,7 @@
                             :accessor used-external-functions)
    (used-symbol-macros :initarg :used-symbol-macros
                        :accessor used-symbol-macros)
+   (func-defs-glsl :initarg :func-defs-glsl :accessor func-defs-glsl)
    (used-macros :initarg :used-macros :accessor used-macros)
    (used-compiler-macros :initarg :used-compiler-macros
                          :accessor used-compiler-macros)

--- a/compiler/string-generation.lisp
+++ b/compiler/string-generation.lisp
@@ -193,7 +193,7 @@
 				  (mapcar #'last1 (uniforms post-proc-obj))
 				  (mapcar #'third (stemcells post-proc-obj)))
 		     (signatures code)
-		     (to-top code))
+		     (func-defs-glsl post-proc-obj))
 	       :if part :collect part))))
 
 ;;----------------------------------------------------------------------

--- a/compiler/translate.lisp
+++ b/compiler/translate.lisp
@@ -245,6 +245,7 @@
                              (used-external-functions env))
    :used-symbol-macros (remove-duplicates (used-symbol-macros env))
    :used-macros (remove-duplicates (used-macros env))
+   :func-defs-glsl (func-defs-glsl env)
    :used-compiler-macros (remove-duplicates (used-compiler-macros env))))
 
 ;;----------------------------------------------------------------------
@@ -505,7 +506,6 @@ The full list: ~s
     (setf code
 	  (copy-code
 	   code
-	   :to-top (remove-duplicates (to-top code) :test #'equal)
 	   :signatures (remove-duplicates (signatures code) :test #'equal)))
     (setf (used-types post-proc-obj)
 	  (remove-duplicates (mapcar #'v-signature (used-types post-proc-obj))

--- a/language/special.lisp
+++ b/language/special.lisp
@@ -532,11 +532,10 @@
 						   (when allow-implicit-args
 						     implicit-args))
 			   (signatures body-obj))))
-	   (top (cons-end (gen-function-body-string
+           (func-glsl-def (gen-function-body-string
 			   glsl-name (unless mainp arg-pairs)
 			   out-arg-pairs type body-obj
-			   (when allow-implicit-args implicit-args))
-			  (to-top body-obj)))
+			   (when allow-implicit-args implicit-args)))
 	   (func (func-spec->user-function
 		  (v-make-f-spec name
 				 (gen-function-transform
@@ -553,13 +552,15 @@
 				 :in-arg-flow-ids in-arg-flow-ids)
 		  env))
 	   (final-env (add-function name func env)))
-      (unless allow-implicit-args
-	(push-non-implicit-function-for-dedup `(,args ,body) func env))
+      (if allow-implicit-args
+          (push-non-implicit-function-for-dedup
+           (gensym) func func-glsl-def env)
+          (push-non-implicit-function-for-dedup
+           `(,args ,body) func func-glsl-def env))
       (values (copy-code body-obj
 			 :type (type-spec->type 'v-none)
 			 :current-line nil
 			 :signatures sigs
-			 :to-top top
 			 :to-block nil
 			 :returns nil
 			 :out-vars (out-vars body-obj)


### PR DESCRIPTION
Both of these are issues around the flow analysis. I am thinking that this will be removed when I finish the compile time values feature as I will be able to reimplement 'spaces' with that.