### PR TITLE
varjo.import: Replace optima with trivia

### DIFF
--- a/import/package.lisp
+++ b/import/package.lisp
@@ -1,5 +1,5 @@
 (uiop:define-package #:varjo.import
-    (:use #:cl :varjo :optima :named-readtables
+    (:use #:cl :varjo :named-readtables
           :glsl-toolkit :rtg-math)
   (:import-from :alexandria :with-gensyms)
   (:import-from :varjo :dbind)

--- a/varjo.import.asd
+++ b/varjo.import.asd
@@ -8,7 +8,6 @@
     :serial t
     :depends-on (#:varjo
                  #:glsl-toolkit
-                 #:optima
                  #:fare-quasiquote-extras
                  #:rtg-math.vari
                  #:split-sequence)


### PR DESCRIPTION
As mentioned in
https://github.com/fare/fare-quasiquote
"trivia's predecessors optima and fare-matcher used to be supported, but both have long been deprecated."

Solves
https://github.com/cbaggers/varjo/issues/240
varjo.import build failure

http://report.quicklisp.org/2020-12-19/failure-report/varjo.html#varjo.import
; caught ERROR:
;   during macroexpansion of (MATCH FORM (# X) ...). Use *BREAK-ON-SIGNALS* to intercept.
;    Non-linear pattern: (STRUCTURE FARE-QUASIQUOTE::LIST* (FARE-QUASIQUOTE::QUOTE LET*) (A A) (FARE-QUASIQUOTE::LIST* (AND (STRUCTURE FARE-QUASIQUOTE::QUOTE (LET* LET*)) B C)) (D D))