### PR TITLE
avoid infinite loop causing crash on CCL

### DIFF
--- a/src/vari.glsl/variables-from-spec.lisp
+++ b/src/vari.glsl/variables-from-spec.lisp
@@ -1,5 +1,4 @@
 (in-package :vari.glsl)
-(in-readtable fn:fn-reader)
 
 (eval-when (:compile-toplevel :load-toplevel :execute)
   (defvar *definitions-missing-from-glsl-spec*
@@ -9,14 +8,15 @@
       )))
 
 (defmacro populate-vars ()
-  (let ((vars (mapcar λ(destructuring-bind
+  (let ((vars (mapcar (lambda (_)
+                        (destructuring-bind
                              (&key lisp-name name type place-p versions
                                    (stage t) &allow-other-keys) _
                          (declare (ignore versions))
                          (assert lisp-name)
                          (let* ((lisp-name (intern lisp-name :vari.glsl))
                                 (lisp-type (parse-gl-type-name type)))
-                           `(,stage ,lisp-name ,name ,lisp-type ,place-p)))
+                           `(,stage ,lisp-name ,name ,lisp-type ,place-p))))
                       (append *definitions-missing-from-glsl-spec*
                               glsl-spec:*variables*))))
 
@@ -25,7 +25,7 @@
          ',(mapcar (lambda (stage-name stage-type-name)
                      (cons stage-type-name
                            (mapcar #'rest (remove-if-not
-                                           λ(eq stage-name _)
+                                           (lambda (_) (eq stage-name _))
                                            vars :key #'first))))
                    (cons t *stage-names*)
                    (cons t *stage-type-names*)))


### PR DESCRIPTION
https://github.com/cbaggers/varjo/issues/239
infinite loop stack overflow crash

This fix from Devon7
https://github.com/cbaggers/cepl/issues/350#issuecomment-693713107

Issue explained in
https://github.com/Clozure/ccl/issues/270#issuecomment-569930991

CLHS NOTINLINE says,

In the presence of a compiler macro definition for function-name,
a notinline declaration prevents that compiler macro from being used.

The macroexpansion machinery contained in the fn library ignores this fact
and recursively compiler-macroexpands the INTERN form which was explicitly
declared NOTINLINE, which leads into infinite loops as demonstrated here.